### PR TITLE
Fix: overflow-x (instead of overflow-y) and change "scroll" to "auto"

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -86,7 +86,7 @@ section pre {
   text-shadow: 0 0 3px #222, 0 0 10px #9ff;
   /*max-width: 25em;*/
   /*margin: 0 auto;*/
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 section pre .cursor {

--- a/css/style.css
+++ b/css/style.css
@@ -86,7 +86,7 @@ section pre {
   text-shadow: 0 0 3px #222, 0 0 10px #9ff;
   /*max-width: 25em;*/
   /*margin: 0 auto;*/
-  overflow-y: scroll;
+  overflow-x: scroll;
 }
 
 section pre .cursor {


### PR DESCRIPTION
The scrollbars should now only appear when there is overflow.