### PR TITLE
Update/highlighting

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -66,6 +66,21 @@ section h1, section h2, section h3, section h4, section h5, section h6 {
 .today {
   font-size: 2em;
   color: #fff;
+  text-shadow: 0 0 0.1em #f90, .0625em .0625em 0 #000;
+}
+
+.today::after {
+  background-color: #f90;
+  color: #000;
+  content: "that's today!";
+  display: inline-block;
+  vertical-align: middle;
+  font-size: 0.4375em;
+  font-weight: normal;
+  margin-left: 2em;
+  padding: .5em .75em;
+  box-shadow: 0.25em 0.5em 0 #000;
+  text-shadow: none;
 }
 
 section h1 {
@@ -76,7 +91,8 @@ section h1 {
 
 section h2 {
     font-size: 1.5em;
-    margin: 1.33em 0 0.66em;
+    margin: -1em 0 0;
+    padding: 1em 0 0.25em;
 }
 
 section ul {

--- a/css/style.css
+++ b/css/style.css
@@ -7,8 +7,9 @@
 body {
   background: #034;
   color:#fff;
-  line-height: 1.5;
+  line-height: 1.45;
   font-family: Arial, "Helvetica Neue", sans-serif;
+  font-size: 100%; /* Works in conjunction with the font-size of the wrapper */
 }
 
 .wrapper {
@@ -37,17 +38,17 @@ section h1 a { color: inherit; text-decoration: none; }
 
 section {
   box-sizing: border-box;
-  max-width: 45em;
+  max-width: 35em;
   margin: 0 auto;
   padding:1em;
 }
 
 section p {
-  margin: 0.5em 0;
+  margin: 1em 0;
 }
 
 section hr {
-  margin: 2em 0;
+  margin: 3em 0;
   border-top: .25em solid #f90;
   border-bottom: .25em solid #000;
   border-left: none;
@@ -97,8 +98,12 @@ section h2 {
 
 section ul {
     list-style: disc outside;
-    margin: 0.5em 0.5em;
+    margin: 1em 0.5em;
     padding: 0 0.25em;
+}
+
+section ul li {
+  margin: 1em 0;
 }
 
 section pre {
@@ -110,6 +115,7 @@ section pre {
   padding: 1em;
   text-shadow: 0 0 3px #222, 0 0 10px #9ff;
   overflow-x: auto;
+  margin-top: 1em;
   /*white-space: pre-wrap;*/
 }
 

--- a/prompts.md
+++ b/prompts.md
@@ -178,8 +178,17 @@ Replicate a natural concept (e.g. gravity, flocking, path following).
 ---
 
 <script>
-    const now = new Date();
-    const frag = "#jan" + now.getDate();
-    document.location = frag;
-    document.querySelector(frag).className = "today";
+    // Uncomment the `if` line to highlight days only in january 2021
+    function setHighlight () {
+        const now = new Date();
+        console.log(now.getFullYear(), now.getMonth());
+        // if (now.getFullYear() !== 2021 || now.getMonth() !== 0) return;
+        const frag = "#jan" + now.getDate();
+        document.location = frag;
+        document.querySelector(frag).classList.add("today");
+    }
+
+    // Make sure we aren't trying to do this before
+    // the browser has loaded the whole page
+    addEventListener('load', setHighlight);
 </script>


### PR DESCRIPTION
As promised! With a preview of the look too. 

<img width="914" alt="Capture d’écran, le 2020-12-10 à 15 32 34" src="https://user-images.githubusercontent.com/861964/101827513-68d7a800-3afe-11eb-8913-2d6e43697363.png">

I believe we've done roughly the same thing with the `script` in the prompts page. I suggest using the one in this pull request, because it listens to the page's complete `load` event, so the JS can't fire before the target title is loaded by the browser.

